### PR TITLE
fix: use more Watches in MachineImageSyncer

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -1,0 +1,10 @@
+// Copyright 2023 Dimitri Koshkin. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import "time"
+
+const (
+	MachineImageSyncerInterval = 1 * time.Hour
+)

--- a/api/v1alpha1/machineimagesyncer_types.go
+++ b/api/v1alpha1/machineimagesyncer_types.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,6 +54,11 @@ type MachineImageSyncerSpec struct {
 	// MachineImageTemplateRef is a reference to a MachineImageTemplate object.
 	// +required
 	MachineImageTemplateRef corev1.ObjectReference `json:"machineImageTemplateRef"`
+
+	// Interval is the time between checks for new versions from the source.
+	// Defaults to 1h.
+	// +optional
+	Interval *time.Duration `json:"interval,omitempty"`
 }
 
 func (s *MachineImageSyncerSpec) GetVersionsFromSource(

--- a/api/v1alpha1/machineimagesyncer_webhook.go
+++ b/api/v1alpha1/machineimagesyncer_webhook.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -57,6 +58,10 @@ func (r *MachineImageSyncer) Default() {
 
 	if r.Spec.MachineImageTemplateRef.Namespace == "" {
 		r.Spec.MachineImageTemplateRef.Namespace = r.Namespace
+	}
+
+	if r.Spec.Interval == nil {
+		r.Spec.Interval = pointer.Duration(MachineImageSyncerInterval)
 	}
 }
 

--- a/config/crd/bases/kubernetesupgraded.dimitrikoshkin.com_machineimagesyncers.yaml
+++ b/config/crd/bases/kubernetesupgraded.dimitrikoshkin.com_machineimagesyncers.yaml
@@ -41,6 +41,11 @@ spec:
           spec:
             description: MachineImageSyncerSpec defines the desired state of MachineImageSyncer.
             properties:
+              interval:
+                description: Interval is the time between checks for new versions
+                  from the source. Defaults to 1h.
+                format: int64
+                type: integer
               machineImageTemplateRef:
                 description: MachineImageTemplateRef is a reference to a MachineImageTemplate
                   object.

--- a/internal/controller/clusterclassclusterupgrader_controller.go
+++ b/internal/controller/clusterclassclusterupgrader_controller.go
@@ -75,7 +75,7 @@ type ClusterClassClusterUpgraderReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/reconcile
 //
-//nolint:dupl // Prefer readability over DRY.
+//nolint:dupl // Prefer readability to DRY.
 func (r *ClusterClassClusterUpgraderReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
@@ -325,12 +325,13 @@ func (r *ClusterClassClusterUpgraderReconciler) SetupWithManager(mgr ctrl.Manage
 		For(&kubernetesupgraderv1.ClusterClassClusterUpgrader{}).
 		Watches(
 			&kubernetesupgraderv1.Plan{},
-			handler.EnqueueRequestsFromMapFunc(r.findObjectsForPlan),
+			handler.EnqueueRequestsFromMapFunc(r.planMapper),
 		).
 		Complete(r)
 }
 
-func (r *ClusterClassClusterUpgraderReconciler) findObjectsForPlan(
+//nolint:dupl // Prefer readability to DRY.
+func (r *ClusterClassClusterUpgraderReconciler) planMapper(
 	ctx context.Context,
 	o client.Object,
 ) []reconcile.Request {

--- a/internal/controller/debianrepositorysource_controller.go
+++ b/internal/controller/debianrepositorysource_controller.go
@@ -64,7 +64,7 @@ type DebianRepositorySourceReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/reconcile
 //
-//nolint:dupl // Prefer readability over DRY.
+//nolint:dupl // Prefer readability to DRY.
 func (r *DebianRepositorySourceReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,

--- a/internal/controller/machineimage_controller.go
+++ b/internal/controller/machineimage_controller.go
@@ -65,7 +65,7 @@ type MachineImageReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/reconcile
 //
-//nolint:dupl // Prefer readability over DRY.
+//nolint:dupl // Prefer readability to DRY.
 func (r *MachineImageReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,

--- a/internal/controller/plan_controller.go
+++ b/internal/controller/plan_controller.go
@@ -65,7 +65,7 @@ type PlanReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.15.0/pkg/reconcile
 //
-//nolint:dupl // Prefer readability over DRY.
+//nolint:dupl // Prefer readability to DRY.
 func (r *PlanReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,


### PR DESCRIPTION
Fixes https://github.com/dkoshkin/kubernetes-upgrader/issues/72

Trigger `MachineImageSyncer` on `MachineImages` and `MachineImageTemplates` and remove the need to periodically reconcile.